### PR TITLE
Check for gorilla arms relic perk when testing if blocking for berser…

### DIFF
--- a/scripts/Overrides/PlayerPuppet.reds
+++ b/scripts/Overrides/PlayerPuppet.reds
@@ -58,7 +58,8 @@ private final func ActivateIconicCyberware() {
 
     let isFocusMode = Equals(IntEnum<gamePSMVision>(psmBlackboard.GetInt(GetAllBlackboardDefs().PlayerStateMachine.Vision)), gamePSMVision.Focus);
     let isBlocking = Equals(meleeWeaponState, gamePSMMeleeWeapon.Block) || Equals(meleeWeaponState, gamePSMMeleeWeapon.BlockAttack)
-        || Equals(meleeWeaponState, gamePSMMeleeWeapon.Deflect) || Equals(meleeWeaponState, gamePSMMeleeWeapon.DeflectAttack);
+        || Equals(meleeWeaponState, gamePSMMeleeWeapon.Deflect) || Equals(meleeWeaponState, gamePSMMeleeWeapon.DeflectAttack)
+        || Equals(meleeWeaponState, gamePSMMeleeWeapon.ChargedHold);
     let isInVehicle = psmBlackboard.GetBool(GetAllBlackboardDefs().PlayerStateMachine.MountedToVehicle);
 
     let attempted = false;


### PR DESCRIPTION
 I found a bug related to the phantom liberty relic perk "LIMITER REMOVAL" which causes the gorilla arms to be in a state while blocking, that is not recognized by Cyberware-Ex, and so triggering berserk was not working. Modifying CyberwareEx.Global.reds  to monitor for ChargedHold status did the trick. I am submitting a PR to do the same modification in the original source.

added the last check in the chain for `ChargedHold`
```
let isBlocking = Equals(meleeWeaponState, gamePSMMeleeWeapon.Block) || Equals(meleeWeaponState, gamePSMMeleeWeapon.BlockAttack)
        || Equals(meleeWeaponState, gamePSMMeleeWeapon.Deflect) || Equals(meleeWeaponState, gamePSMMeleeWeapon.DeflectAttack) 
        || Equals(meleeWeaponState, gamePSMMeleeWeapon.ChargedHold);
```

