### PR TITLE
Update RegisterCyberwareSlots.reds

### DIFF
--- a/scripts/Tweaks/RegisterCyberwareSlots.reds
+++ b/scripts/Tweaks/RegisterCyberwareSlots.reds
@@ -22,12 +22,12 @@ class RegisterCyberwareSlots extends ScriptableTweak {
             }
 
             for extraSlot in expansion.extraSlots {
-                ArrayPush(equipmentAreaSlots,
-                    CyberwareHelper.CreateEquipSlotRecord(
+                let TBSlotRecord:TweakDBID = CyberwareHelper.CreateEquipSlotRecord(
                         expansion.equipmentArea,
                         ArraySize(equipmentAreaSlots),
                         extraSlot.requiredPerk,
-                        extraSlot.requiredLevel));
+                        extraSlot.requiredLevel);
+                ArrayPush(equipmentAreaSlots, TBSlotRecord);
             }
 
             TweakDBManager.SetFlat(equipmentAreaID + t".defaultNumSlots", defaultNumSlots);


### PR DESCRIPTION
Redscript has a bug, If you directly call 'ArrayPush' to add a 'function(ArraySize(...))' element, the counter will erroneously + 1. 

This is also the reason for installation errors when installing MusculoskeletalSystem Cyberware after having PERK (because the cyberware equipment slot index is offset by 1)